### PR TITLE
QR Gap check - throws exception on double qr code feed.

### DIFF
--- a/PdfSplitterLib/PdfChunk.cs
+++ b/PdfSplitterLib/PdfChunk.cs
@@ -30,6 +30,10 @@ namespace PdfSplitterLib
         //Methods
         //***************************************************************************
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
         public override string ToString()
         {
             return chunkName + " : PAGES " + firstPage + " - " + lastPage;

--- a/PdfSplitterLib/PdfChunker.cs
+++ b/PdfSplitterLib/PdfChunker.cs
@@ -68,6 +68,7 @@ namespace PdfSplitterLib
             GhostscriptRasterizer Rasterizer = null;    //Rasterizer
             Bitmap pageImg; //Image of one PDF page.
             string docType; //Value of document-type property in QR code json.
+            int qrCodeGap = 0;
 
             //Only process PDFs
             if (SrcIsPdf())
@@ -96,6 +97,18 @@ namespace PdfSplitterLib
                         {
                             qrCount++; //Increment found qr code count.
 
+                            //Throw exception if more than one QR code is found 
+                            //and QR Gap is less than 1 (Double Feed)
+                            if (qrCount > 1 && qrCodeGap < 1)
+                            {
+                                throw new ApplicationException("File: " + SrcPdf.Name + " has two consecutive QR code pages. "
+                                                                + "QR code double feed will result with an empty document.");
+                            }
+                            else
+                            {
+                                qrCodeGap = 0;  //Reset Gap//
+                            }
+
                             //Console.WriteLine("DOC TYPE: {0}{1}", docType, Environment.NewLine); //TEST OUTPUT
 
                             //Create chunk with src page # for first page (The one after QR page) and name (srcFileName_docType_qr#).
@@ -113,6 +126,9 @@ namespace PdfSplitterLib
                         {
                             //Else count as a content page
                             contentCount++;
+
+                            //Increment QR gap//
+                            qrCodeGap++;
                         }
                     }
                     //END LOOP


### PR DESCRIPTION
The PDF Chuncker will throw an exception while searching for PDF chunks if there is not at least
a one page gap between QR code.
